### PR TITLE
Apply fixes to gnulib to resolve bulk of tar tests

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -21,6 +21,6 @@ totalTests=$(tail -50 ${chk} | egrep 'ERROR.*tests were run' | awk '{print $2;}'
 cat <<ZZ
 actualFailures:$failures
 totalTests:$totalTests
-expectedFailures:117
+expectedFailures:26
 ZZ
 }

--- a/patches/PR1.patch
+++ b/patches/PR1.patch
@@ -1,0 +1,55 @@
+diff --git a/gnu/fdopendir.c b/gnu/fdopendir.c
+index 451b4e1..cf9a452 100644
+--- a/gnu/fdopendir.c
++++ b/gnu/fdopendir.c
+@@ -151,7 +151,9 @@ fdopendir_with_dup (int fd, int older_dupfd, struct saved_cwd const *cwd)
+         }
+       else
+         {
++#ifndef __MVS__
+           close (fd);
++#endif
+           dir = fd_clone_opendir (dupfd, cwd);
+           saved_errno = errno;
+           if (! dir)
+diff --git a/gnu/openat-proc.c b/gnu/openat-proc.c
+index 4f8be90..dd52560 100644
+--- a/gnu/openat-proc.c
++++ b/gnu/openat-proc.c
+@@ -25,6 +25,7 @@
+ #include <sys/stat.h>
+ #include <fcntl.h>
+ 
++#include <termios.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+@@ -53,7 +54,27 @@ openat_proc_name (char buf[OPENAT_BUFFER_SIZE], int fd, char const *file)
+       return buf;
+     }
+ 
+-#ifndef __KLIBC__
++#ifdef __MVS__
++  {
++    char dir[_XOPEN_PATH_MAX];
++    int rc = w_ioctl(fd, _IOCC_GPN, _XOPEN_PATH_MAX, dir);
++    if (rc == 0) {
++      __e2a_l(dir, _XOPEN_PATH_MAX);
++    }
++    size_t bufsize;
++    dirlen = strlen (dir);
++    bufsize = dirlen + 1 + strlen (file) + 1; /* 1 for '/', 1 for null */
++    if (OPENAT_BUFFER_SIZE < bufsize)
++      {
++        result = malloc (bufsize);
++        if (! result)
++          return NULL;
++      }
++
++    strcpy (result, dir);
++    result[dirlen++] = '/';
++  }
++#elif !defined( __KLIBC__)
+ # define PROC_SELF_FD_FORMAT "/proc/self/fd/%d/"
+   {
+     enum {


### PR DESCRIPTION
* Same fix as findutils and coreutils. Since this is pervasive we should try to push the change to gnulib upstream
* Test results are now:
```
Test results: 181 tests pass out of 207 tests - 87.44% success rate
```
Previously it was at 44%